### PR TITLE
Pass ISO file contents via WinRM stdin to avoid command line length l…

### DIFF
--- a/internal/client/iso.go
+++ b/internal/client/iso.go
@@ -3,11 +3,25 @@ package client
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
-	"sort"
 	"strings"
 )
 
+// buildCreateISOStdinData builds a JSON payload of filename -> base64-encoded content
+// to be passed via stdin to the ISO creation script.
+func buildCreateISOStdinData(files map[string]string) string {
+	payload := make(map[string]string, len(files))
+	for name, content := range files {
+		payload[name] = base64.StdEncoding.EncodeToString([]byte(content))
+	}
+	data, _ := json.Marshal(payload)
+	return string(data)
+}
+
+// buildCreateISOScript builds a PowerShell script that reads file data from stdin (as JSON
+// with base64-encoded values), writes them to a temp directory, and creates an ISO.
+// File contents are passed via stdin to avoid Windows command-line length limits.
 func buildCreateISOScript(opts ISOOptions) string {
 	var sb strings.Builder
 	sb.WriteString("$ErrorActionPreference = 'Stop'\n")
@@ -15,28 +29,15 @@ func buildCreateISOScript(opts ISOOptions) string {
 	sb.WriteString("New-Item -ItemType Directory -Path $tempDir -Force | Out-Null\n")
 	sb.WriteString("try {\n")
 
-	// Write each file by base64-decoding its content
-	// Sort keys for deterministic script generation
-	filenames := make([]string, 0, len(opts.Files))
-	for name := range opts.Files {
-		filenames = append(filenames, name)
-	}
-	sort.Strings(filenames)
-
-	for _, name := range filenames {
-		content := opts.Files[name]
-		b64 := base64.StdEncoding.EncodeToString([]byte(content))
-		escapedName := EscapePSString(name)
-		// Create parent directories for nested paths (e.g. "openstack/latest/meta_data.json")
-		sb.WriteString(fmt.Sprintf(
-			"  $fp = Join-Path $tempDir %s; $fd = Split-Path -Parent $fp; if ($fd -ne $tempDir) { New-Item -ItemType Directory -Path $fd -Force | Out-Null }\n",
-			escapedName,
-		))
-		sb.WriteString(fmt.Sprintf(
-			"  [System.IO.File]::WriteAllBytes($fp, [System.Convert]::FromBase64String('%s'))\n",
-			b64,
-		))
-	}
+	// Read file data from stdin as JSON {filename: base64content}
+	sb.WriteString("  $jsonInput = @($input) -join ''\n")
+	sb.WriteString("  $files = $jsonInput | ConvertFrom-Json\n")
+	sb.WriteString("  foreach ($prop in $files.PSObject.Properties) {\n")
+	sb.WriteString("    $fp = Join-Path $tempDir $prop.Name\n")
+	sb.WriteString("    $fd = Split-Path -Parent $fp\n")
+	sb.WriteString("    if ($fd -ne $tempDir) { New-Item -ItemType Directory -Path $fd -Force | Out-Null }\n")
+	sb.WriteString("    [System.IO.File]::WriteAllBytes($fp, [System.Convert]::FromBase64String($prop.Value))\n")
+	sb.WriteString("  }\n")
 
 	// Create the ISO using IMAPI2
 	sb.WriteString(fmt.Sprintf("  $isoPath = %s\n", EscapePSString(opts.Path)))
@@ -96,7 +97,8 @@ func buildGetISOCommand(path string) string {
 
 func (c *WinRMClient) CreateISO(ctx context.Context, opts ISOOptions) (*ISOInfo, error) {
 	var info ISOInfo
-	err := c.ps.RunJSON(ctx, buildCreateISOScript(opts), &info)
+	stdinData := buildCreateISOStdinData(opts.Files)
+	err := c.ps.RunJSONWithInput(ctx, buildCreateISOScript(opts), stdinData, &info)
 	if err != nil {
 		return nil, fmt.Errorf("create ISO %q: %w", opts.Path, err)
 	}

--- a/internal/client/iso_test.go
+++ b/internal/client/iso_test.go
@@ -1,11 +1,13 @@
 package client
 
 import (
+	"encoding/base64"
+	"encoding/json"
 	"strings"
 	"testing"
 )
 
-func TestBuildCreateISOScript_FlatFiles(t *testing.T) {
+func TestBuildCreateISOScript_ReadsFromStdin(t *testing.T) {
 	script := buildCreateISOScript(ISOOptions{
 		Path:        `C:\VMs\test\seed.iso`,
 		VolumeLabel: "cidata",
@@ -16,34 +18,66 @@ func TestBuildCreateISOScript_FlatFiles(t *testing.T) {
 	})
 
 	for _, s := range []string{
-		"Join-Path $tempDir 'meta-data'",
-		"Join-Path $tempDir 'user-data'",
+		"$jsonInput",
+		"ConvertFrom-Json",
+		"$prop.Name",
+		"FromBase64String",
 		"VolumeName = 'cidata'",
 	} {
 		if !strings.Contains(script, s) {
 			t.Errorf("script missing %q", s)
 		}
 	}
+
+	// Script should NOT contain embedded base64 data (that goes via stdin now)
+	b64 := base64.StdEncoding.EncodeToString([]byte("#cloud-config\n"))
+	if strings.Contains(script, b64) {
+		t.Error("script should not embed base64 data; file contents go via stdin")
+	}
 }
 
-func TestBuildCreateISOScript_SubdirectoryPaths(t *testing.T) {
+func TestBuildCreateISOScript_SubdirectorySupport(t *testing.T) {
 	script := buildCreateISOScript(ISOOptions{
 		Path:        `C:\VMs\test\config.iso`,
 		VolumeLabel: "config-2",
 		Files: map[string]string{
 			"openstack/latest/meta_data.json": `{"uuid": "test"}`,
-			"openstack/latest/user_data":      "#cloud-config\n",
 		},
 	})
 
-	// Must create parent directories before writing files
 	if !strings.Contains(script, "New-Item -ItemType Directory") {
 		t.Error("script should create parent directories for nested paths")
 	}
-	if !strings.Contains(script, "'openstack/latest/meta_data.json'") {
-		t.Error("script should reference the full nested path")
-	}
 	if !strings.Contains(script, "'config-2'") {
 		t.Error("script should use the specified volume label")
+	}
+}
+
+func TestBuildCreateISOStdinData(t *testing.T) {
+	files := map[string]string{
+		"meta-data": "instance-id: test\n",
+		"user-data": "#cloud-config\nhostname: myvm\n",
+	}
+	stdinJSON := buildCreateISOStdinData(files)
+
+	var payload map[string]string
+	if err := json.Unmarshal([]byte(stdinJSON), &payload); err != nil {
+		t.Fatalf("stdin data is not valid JSON: %v", err)
+	}
+
+	for name, content := range files {
+		b64, ok := payload[name]
+		if !ok {
+			t.Errorf("missing file %q in stdin payload", name)
+			continue
+		}
+		decoded, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			t.Errorf("file %q: invalid base64: %v", name, err)
+			continue
+		}
+		if string(decoded) != content {
+			t.Errorf("file %q: got %q, want %q", name, decoded, content)
+		}
 	}
 }

--- a/internal/client/network_adapter_test.go
+++ b/internal/client/network_adapter_test.go
@@ -19,6 +19,10 @@ type mockPS struct {
 }
 
 func (m *mockPS) Run(ctx context.Context, command string) (string, string, error) {
+	return m.RunWithInput(ctx, command, "")
+}
+
+func (m *mockPS) RunWithInput(ctx context.Context, command string, stdin string) (string, string, error) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.runCalls++
@@ -26,6 +30,10 @@ func (m *mockPS) Run(ctx context.Context, command string) (string, string, error
 }
 
 func (m *mockPS) RunJSON(ctx context.Context, command string, result any) error {
+	return m.RunJSONWithInput(ctx, command, "", result)
+}
+
+func (m *mockPS) RunJSONWithInput(ctx context.Context, command string, stdin string, result any) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.runJSONCalls >= len(m.jsonResponses) {

--- a/internal/client/powershell.go
+++ b/internal/client/powershell.go
@@ -12,7 +12,9 @@ import (
 // PSExecutor abstracts PowerShell command execution for testing.
 type PSExecutor interface {
 	Run(ctx context.Context, command string) (string, string, error)
+	RunWithInput(ctx context.Context, command string, stdin string) (string, string, error)
 	RunJSON(ctx context.Context, command string, result any) error
+	RunJSONWithInput(ctx context.Context, command string, stdin string, result any) error
 }
 
 // EscapePSString wraps a value in single quotes with internal single quotes doubled.
@@ -33,7 +35,12 @@ func NewPowerShellRunner(client *winrm.Client) *PowerShellRunner {
 
 // Run executes a PowerShell command and returns stdout, stderr, and any error.
 func (r *PowerShellRunner) Run(ctx context.Context, command string) (string, string, error) {
-	stdout, stderr, exitCode, err := r.client.RunPSWithContextWithString(ctx, command, "")
+	return r.RunWithInput(ctx, command, "")
+}
+
+// RunWithInput executes a PowerShell command with stdin data and returns stdout, stderr, and any error.
+func (r *PowerShellRunner) RunWithInput(ctx context.Context, command string, stdin string) (string, string, error) {
+	stdout, stderr, exitCode, err := r.client.RunPSWithContextWithString(ctx, command, stdin)
 	if err != nil {
 		return "", "", fmt.Errorf("winrm error: %w", err)
 	}
@@ -43,10 +50,19 @@ func (r *PowerShellRunner) Run(ctx context.Context, command string) (string, str
 	return strings.TrimSpace(stdout), strings.TrimSpace(stderr), nil
 }
 
+// RunJSONWithInput executes a PowerShell command with stdin data and unmarshals the JSON output into result.
+func (r *PowerShellRunner) RunJSONWithInput(ctx context.Context, command string, stdin string, result any) error {
+	return r.runJSONInternal(ctx, command, stdin, result)
+}
+
 // RunJSON executes a PowerShell command and unmarshals the JSON output into result.
 // Handles PowerShell's ConvertTo-Json which may return an array even for single objects.
 func (r *PowerShellRunner) RunJSON(ctx context.Context, command string, result any) error {
-	stdout, stderr, err := r.Run(ctx, command)
+	return r.runJSONInternal(ctx, command, "", result)
+}
+
+func (r *PowerShellRunner) runJSONInternal(ctx context.Context, command string, stdin string, result any) error {
+	stdout, stderr, err := r.RunWithInput(ctx, command, stdin)
 	if err != nil {
 		if stderr != "" {
 			return fmt.Errorf("%w (stderr: %s)", err, stderr)


### PR DESCRIPTION
…imit

The ISO creation script previously embedded base64-encoded file contents directly in the PowerShell command string. Combined with the C# IStream helper class, this exceeded the Windows command line limit (~8191 chars) when files contained large content like multi-line cloud-init user-data.

Refactored to pass file contents as a JSON payload via WinRM stdin. The PowerShell script now reads from $input, parses the JSON, and decodes each file from base64. This removes the command line length constraint entirely.

Changes:
- Add RunWithInput() and RunJSONWithInput() to PSExecutor interface and PowerShellRunner for stdin support over WinRM
- Refactor buildCreateISOScript() to read files from stdin JSON
- Add buildCreateISOStdinData() helper to build the stdin payload
- Update CreateISO() to use RunJSONWithInput()
- Update tests for stdin-based approach