### PR TITLE
Fix VHD replacement not setting VM security principal permissions

### DIFF
--- a/internal/client/vm.go
+++ b/internal/client/vm.go
@@ -139,6 +139,13 @@ func (c *WinRMClient) SetVMState(ctx context.Context, name string, state VMState
 	var cmd string
 	switch state {
 	case VMStateRunning:
+		// Grant the VM's security principal full control on all attached VHDs
+		// before starting. This is necessary because VHD replacement (destroy +
+		// recreate) produces a new file that lacks the ACL entry Hyper-V set
+		// when the drive was first attached.
+		if err := c.grantVMStorageAccess(ctx, name); err != nil {
+			return fmt.Errorf("grant VM %q storage access: %w", name, err)
+		}
 		cmd = fmt.Sprintf("Start-VM -Name %s -ErrorAction Stop", EscapePSString(name))
 	case VMStateOff:
 		cmd = fmt.Sprintf("Stop-VM -Name %s -Force -TurnOff -ErrorAction Stop", EscapePSString(name))
@@ -152,4 +159,23 @@ func (c *WinRMClient) SetVMState(ctx context.Context, name string, state VMState
 		}
 		return nil
 	})
+}
+
+// grantVMStorageAccess grants the VM's security principal (NT VIRTUAL MACHINE\{VMId})
+// full control on all VHD files attached to the VM. This ensures the VM can access
+// VHDs that were replaced (destroyed and recreated) after the initial attachment.
+func (c *WinRMClient) grantVMStorageAccess(ctx context.Context, name string) error {
+	_, _, err := c.ps.Run(ctx, buildGrantVMStorageAccessCommand(name))
+	return err
+}
+
+func buildGrantVMStorageAccessCommand(name string) string {
+	return fmt.Sprintf(`$vmId = (Get-VM -Name %[1]s -ErrorAction Stop).VMId
+Get-VMHardDiskDrive -VMName %[1]s -ErrorAction SilentlyContinue | Where-Object { $_.Path } | ForEach-Object {
+    $acl = Get-Acl -LiteralPath $_.Path
+    $rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
+        "NT VIRTUAL MACHINE\$vmId", 'FullControl', 'Allow')
+    $acl.SetAccessRule($rule)
+    Set-Acl -LiteralPath $_.Path -AclObject $acl
+}`, EscapePSString(name))
 }

--- a/internal/client/vm_test.go
+++ b/internal/client/vm_test.go
@@ -194,6 +194,32 @@ func TestBuildSetVMFirmwareCommandInjection(t *testing.T) {
 	}
 }
 
+func TestBuildGrantVMStorageAccessCommand(t *testing.T) {
+	cmd := buildGrantVMStorageAccessCommand("test-vm")
+	expected := []string{
+		"Get-VM -Name 'test-vm'",
+		"Get-VMHardDiskDrive -VMName 'test-vm'",
+		"NT VIRTUAL MACHINE",
+		"FullControl",
+		"Get-Acl -LiteralPath",
+		"Set-Acl -LiteralPath",
+		"SetAccessRule",
+		"FileSystemAccessRule",
+	}
+	for _, s := range expected {
+		if !containsStr(cmd, s) {
+			t.Errorf("command missing expected substring %q", s)
+		}
+	}
+}
+
+func TestBuildGrantVMStorageAccessCommandInjection(t *testing.T) {
+	cmd := buildGrantVMStorageAccessCommand("test'; Remove-VM *; '")
+	if !containsStr(cmd, "'test''") {
+		t.Errorf("injection not properly escaped: %q", cmd)
+	}
+}
+
 func containsStr(haystack, needle string) bool {
 	return strings.Contains(haystack, needle)
 }


### PR DESCRIPTION
## Summary
- Before starting a VM, grant `NT VIRTUAL MACHINE\{VMId}` full control on all attached VHD files
- Uses `SetAccessRule` so it's idempotent — no-op when permissions already exist
- Fixes the "Access is denied" (0x80070005) error when a `hyperv_vhd` is replaced and the VM tries to start

Fixes #11

## Test plan
- [ ] Unit tests pass (`go test ./...`)
- [ ] Acceptance test: create VM with differencing disk, change `parent_path`, `terraform apply` — VM should start without permission errors
- [ ] Verify idempotency: starting a VM whose VHDs already have correct permissions should succeed without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)